### PR TITLE
enable the test using jest

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -9,4 +9,4 @@ jobs:
     - run: yarn -v
     - uses: actions/checkout@v2
     - run: yarn install
-    - run: yarn run test
+    - run: yarn run jest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+yarn.lock

--- a/date.test.js
+++ b/date.test.js
@@ -1,0 +1,42 @@
+const holiday_jp = require('./holiday_jp.min')
+
+function judgeDate(youbi, holiday) {
+    if ((youbi == 1 || youbi == 2 || youbi == 3 || youbi == 4 || youbi == 5) && !holiday) {
+        return '平日';
+    } else if (youbi == 6 && !holiday) {
+        return '土曜日';
+    } else {
+        return '休日';
+    }
+}
+
+describe('日付判定', () => {
+
+    it('平日', () => {
+        var date = new Date('2021-11-05');
+        var youbi = date.getDay();
+        var holiday = holiday_jp.isHoliday(date);
+        expect(judgeDate(youbi, holiday)).toBe('平日');
+    });
+
+    it('土曜日', () => {
+        var date = new Date('2021-11-06');
+        var youbi = date.getDay();
+        var holiday = holiday_jp.isHoliday(date);
+        expect(judgeDate(youbi, holiday)).toBe('土曜日');
+    });
+
+    it('日曜日', () => {
+        var date = new Date('2021-11-07');
+        var youbi = date.getDay();
+        var holiday = holiday_jp.isHoliday(date);
+        expect(judgeDate(youbi, holiday)).toBe('休日');
+    });
+
+    it('祝日', () => {
+        var date = new Date('2021-11-03');
+        var youbi = date.getDay();
+        var holiday = holiday_jp.isHoliday(date);
+        expect(judgeDate(youbi, holiday)).toBe('休日');
+    });
+});


### PR DESCRIPTION
Jestでのテストに対応させました。 #3 
(@Black092 氏のコミットから若干の変更)

push時にworkflowが実行されます。
([act](https://github.com/nektos/act)にてテスト済み)

曜日判定のテスト用ファイルとして[date.test.js](https://github.com/take0x/oit_bus/blob/jest/date.test.js)を作成しています。
こちらはJestの動作確認用に作成したため、行いたいテストに応じて適宜変更してください。